### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1ed36f87416492f8a7529f201de656ffda5346cff3cce6cf0c16b63081dd35"
+checksum = "2f8a22b8700660fbca67c4d6cd8fc585bf4b837319fe1c0ec81b5d2355c01143"
 dependencies = [
  "aws-credential-types",
  "aws-http",
@@ -1863,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.5"
+version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
  "ring",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "nysm"
 
 [dependencies]
 aws-config = "0.56.1"
-aws-sdk-secretsmanager = "0.31.1"
+aws-sdk-secretsmanager = "0.32.0"
 tokio = { version = "1", features = ["full"] }
 bat = "0.23.0"
 serde = "1"


### PR DESCRIPTION
In order to ensure we are not relying on a yanked version of rustls-webpki, this commit updates the dependency. Additionally, we bump up the aws-sdk-secretsmanager crate as well.