### PR TITLE
Feat: Add support for creating secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 Nysm is a command line utility designed to make interacting with a Secrets
 Provider like AWS Secrets Manager simple and easy. You can get a list of your
-existing secrets, show the value of a specific secret, or update the value of a
-specific secret.
+existing secrets, show the value of a specific secret, update the value of a
+specific secret, or even create new secrets.
 
 # Installation
 
@@ -36,4 +36,10 @@ Edit an existing secret:
 
 ```sh
 nysm edit some-secret-id
+```
+
+Create a new secret:
+
+```sh
+nysm create some-new-secret-id -d "This is a description for the secret"
 ```

--- a/src/client.rs
+++ b/src/client.rs
@@ -33,6 +33,16 @@ pub struct UpdateSecretValueResult {
   pub version_id: Option<String>,
 }
 
+/// Represents a response from a secret provider after creating a new secret.
+pub struct CreateSecretResult {
+  /// Name of secret
+  pub name: Option<String>,
+  /// Uniform resource locator of secret
+  pub uri: Option<String>,
+  /// Version of secret after create operation
+  pub version_id: Option<String>,
+}
+
 /// Represents a response from a secret provider that wraps around
 /// a list of secrets.
 #[derive(Default)]
@@ -127,4 +137,20 @@ pub trait QuerySecrets {
     secret_id: String,
     secret_value: String,
   ) -> Result<UpdateSecretValueResult, NysmError>;
+
+  /// Creates a new secret with the specified value and optional description.
+  ///
+  /// # Arguments
+  /// * `secret_id` - String identifier for the new secret
+  /// * `secret_value` - String contents to use as the secret value
+  /// * `description` - Optional description for the secret
+  ///
+  /// # Returns
+  /// Returns a result containing either the [CreateSecretResult] struct or an [NysmError].
+  async fn create_secret(
+    &self,
+    secret_id: String,
+    secret_value: String,
+    description: Option<String>,
+  ) -> Result<CreateSecretResult, NysmError>;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,10 @@ pub enum NysmError {
   /// Error occurs when updating a secret's string value fails
   #[error("Unable to update secret value")]
   AwsSecretValueUpdate,
+
+  /// Error occurs when creating a secret fails
+  #[error("Unable to create secret")]
+  AwsSecretValueCreate,
 }
 
 impl PartialEq for NysmError {
@@ -98,6 +102,12 @@ mod tests {
   fn test_aws_secret_value_update_error() {
     let error = NysmError::AwsSecretValueUpdate;
     assert_eq!(error.to_string(), "Unable to update secret value");
+  }
+
+  #[test]
+  fn test_aws_secret_value_create_error() {
+    let error = NysmError::AwsSecretValueCreate;
+    assert_eq!(error.to_string(), "Unable to create secret");
   }
 
   #[test]


### PR DESCRIPTION
In order to enable creating secrets from the cli much like you edit an
existing secret, this commit adds a new subcommand along with an
implementation. It updates the QuerySecrets trait and adds a real
implementation for aws to actually create the secret. And finally, it
adds a new error when we can't properly create the secret.
