### PR TITLE
Chore: Update explicit runners for architectures

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -18,3 +18,10 @@ install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
 allow-dirty = ["ci", "msi"]
+
+[dist.github-custom-runners]
+aarch64-unknown-linux-gnu = "ubuntu-22.04"
+aarch64-pc-windows-msvc = "ubuntu-22.04"
+x86_64-unknown-linux-gnu = "ubuntu-22.04"
+x86_64-unknown-linux-musl = "ubuntu-22.04"
+x86_64-pc-windows-msvc = "ubuntu-22.04"


### PR DESCRIPTION
In order to ensure we don't use the ubuntu-20.04 image from github
actions as it's no longer available, this commit explicitly sets it to
ubuntu-22.04 instead which should still be supported.
