### PR TITLE
Chore: Update rust version to 1.86.0 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/Endoze/nysm"
 documentation = "https://docs.rs/nysm"
 homepage = "https://github.com/Endoze/nysm"
-rust-version = "1.87.0"
+rust-version = "1.86.0"
 
 [lib]
 name = "nysm"


### PR DESCRIPTION
In order to ensure we can build in ci, this commit updates the version
of rust for the project to 1.86.0 in the Cargo.toml.
