### PR TITLE
Chore: Remove windows targets

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,9 +8,9 @@ cargo-dist-version = "0.28.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell"]
+installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Path that installers should place binaries in
@@ -21,7 +21,5 @@ allow-dirty = ["ci", "msi"]
 
 [dist.github-custom-runners]
 aarch64-unknown-linux-gnu = "ubuntu-22.04"
-aarch64-pc-windows-msvc = "ubuntu-22.04"
 x86_64-unknown-linux-gnu = "ubuntu-22.04"
 x86_64-unknown-linux-musl = "ubuntu-22.04"
-x86_64-pc-windows-msvc = "ubuntu-22.04"


### PR DESCRIPTION
In order to ensure we can properly build artifacts in ci, this commit
removes windows targets which fail to build due to some strange github
actions issues.
