### PR TITLE
Feat: Add windows builds back

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,9 +8,9 @@ cargo-dist-version = "0.28.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell"]
+installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Path that installers should place binaries in


### PR DESCRIPTION
In order to build releases for windows again, this commit adds the
target triplets for x86_64 and arm for windows builds. They broke
previously as we were overwriting the build runners to use ubuntu when
they need to use their defaults of windows.
