### PR TITLE
Feat: Add support for github actions secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_colours"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +118,12 @@ name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "async-trait"
@@ -728,6 +749,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +1014,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ed25519"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+dependencies = [
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,8 +1213,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1467,11 +1514,25 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
+ "log",
  "rustls 0.23.27",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -1494,6 +1555,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.57.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1621,6 +1706,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1766,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1818,18 @@ checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "libsodium-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "walkdir",
 ]
 
 [[package]]
@@ -1833,6 +1955,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,13 +1997,17 @@ dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
  "aws-types",
+ "base64 0.22.1",
  "bat",
  "clap",
  "futures",
  "lazy_static",
+ "octocrab",
+ "rustls 0.23.27",
  "serde",
  "serde_json",
  "serde_yml",
+ "sodiumoxide",
  "tabled",
  "tempfile",
  "thiserror 2.0.12",
@@ -1885,6 +2021,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "octocrab"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86996964f8b721067b6ed238aa0ccee56ecad6ee5e714468aa567992d05d2b91"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "either",
+ "futures",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonwebtoken",
+ "once_cell",
+ "percent-encoding",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "snafu",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "url",
+ "web-time",
 ]
 
 [[package]]
@@ -1977,10 +2153,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2246,7 +2452,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.3",
  "subtle",
@@ -2364,6 +2572,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,11 +2655,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -2536,6 +2775,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +2808,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snafu"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320b01e011bf8d5d7a4a4a4be966d9160968935849c83b918827f6a435e7f627"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,6 +2836,18 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "sodiumoxide"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
+dependencies = [
+ "ed25519",
+ "libc",
+ "libsodium-sys",
+ "serde",
 ]
 
 [[package]]
@@ -2594,6 +2884,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -2924,8 +3220,34 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2946,6 +3268,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3022,6 +3345,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -3163,6 +3487,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3301,6 +3636,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,13 @@ async-trait = "0.1"
 aws-config = "1.6.1"
 aws-sdk-secretsmanager = "1.74.0"
 aws-types = "1.3.7"
+base64 = "0.22"
 bat = "0.25"
-clap = { version = "4.4", features = ["derive"]}
+clap = { version = "4.4", features = ["derive", "env"]}
+octocrab = "0.44"
+rustls = { version = "0.23", features = ["ring"] }
 serde = { version = "1", features = ["derive"] }
+sodiumoxide = "0.2"
 serde_json = "1"
 serde_yml = "0.0.12"
 tabled = "0.19"

--- a/src/client.rs
+++ b/src/client.rs
@@ -119,6 +119,19 @@ impl<'a> Iterator for GetSecretsResultIter<'a> {
 #[async_trait]
 #[cfg(not(tarpaulin_include))]
 pub trait QuerySecrets {
+  /// Indicates whether this provider supports reading secret values.
+  ///
+  /// Some providers (like GitHub Actions) only support write operations
+  /// for security reasons. This method allows the CLI to adapt its
+  /// behavior accordingly.
+  ///
+  /// # Returns
+  /// Returns `true` if the provider supports reading secret values,
+  /// `false` if it only supports write operations.
+  fn supports_read(&self) -> bool {
+    true
+  }
+
   /// Requests a list of secrets from the secret provider.
   ///
   /// # Returns
@@ -172,4 +185,179 @@ pub trait QuerySecrets {
   /// # Returns
   /// Returns a result containing either the [DeleteSecretResult] struct or an [NysmError].
   async fn delete_secret(&self, secret_id: String) -> Result<DeleteSecretResult, NysmError>;
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use async_trait::async_trait;
+
+  struct MockReadableProvider;
+  struct MockWriteOnlyProvider;
+
+  #[async_trait]
+  impl QuerySecrets for MockReadableProvider {
+    async fn secrets_list(&self) -> Result<ListSecretsResult, NysmError> {
+      Ok(ListSecretsResult::default())
+    }
+
+    async fn secret_value(&self, _secret_id: String) -> Result<GetSecretValueResult, NysmError> {
+      Ok(GetSecretValueResult {
+        secret: "test-value".to_string(),
+      })
+    }
+
+    async fn update_secret_value(
+      &self,
+      _secret_id: String,
+      _secret_value: String,
+    ) -> Result<UpdateSecretValueResult, NysmError> {
+      Ok(UpdateSecretValueResult {
+        name: Some("test".to_string()),
+        uri: None,
+        version_id: None,
+      })
+    }
+
+    async fn create_secret(
+      &self,
+      _secret_id: String,
+      _secret_value: String,
+      _description: Option<String>,
+    ) -> Result<CreateSecretResult, NysmError> {
+      Ok(CreateSecretResult {
+        name: Some("test".to_string()),
+        uri: None,
+        version_id: None,
+      })
+    }
+
+    async fn delete_secret(&self, _secret_id: String) -> Result<DeleteSecretResult, NysmError> {
+      Ok(DeleteSecretResult {
+        name: Some("test".to_string()),
+        uri: None,
+        deletion_date: None,
+      })
+    }
+  }
+
+  #[async_trait]
+  impl QuerySecrets for MockWriteOnlyProvider {
+    fn supports_read(&self) -> bool {
+      false
+    }
+
+    async fn secrets_list(&self) -> Result<ListSecretsResult, NysmError> {
+      Ok(ListSecretsResult::default())
+    }
+
+    async fn secret_value(&self, _secret_id: String) -> Result<GetSecretValueResult, NysmError> {
+      Err(NysmError::SecretNotReadable)
+    }
+
+    async fn update_secret_value(
+      &self,
+      _secret_id: String,
+      _secret_value: String,
+    ) -> Result<UpdateSecretValueResult, NysmError> {
+      Ok(UpdateSecretValueResult {
+        name: Some("test".to_string()),
+        uri: None,
+        version_id: None,
+      })
+    }
+
+    async fn create_secret(
+      &self,
+      _secret_id: String,
+      _secret_value: String,
+      _description: Option<String>,
+    ) -> Result<CreateSecretResult, NysmError> {
+      Ok(CreateSecretResult {
+        name: Some("test".to_string()),
+        uri: None,
+        version_id: None,
+      })
+    }
+
+    async fn delete_secret(&self, _secret_id: String) -> Result<DeleteSecretResult, NysmError> {
+      Ok(DeleteSecretResult {
+        name: Some("test".to_string()),
+        uri: None,
+        deletion_date: None,
+      })
+    }
+  }
+
+  #[test]
+  fn test_default_supports_read_returns_true() {
+    let provider = MockReadableProvider;
+    assert!(provider.supports_read());
+  }
+
+  #[test]
+  fn test_write_only_provider_supports_read_returns_false() {
+    let provider = MockWriteOnlyProvider;
+    assert!(!provider.supports_read());
+  }
+
+  #[tokio::test]
+  async fn test_write_only_provider_returns_error_on_secret_value() {
+    let provider = MockWriteOnlyProvider;
+    let result = provider.secret_value("test-secret".to_string()).await;
+    assert!(matches!(result, Err(NysmError::SecretNotReadable)));
+  }
+
+  #[test]
+  fn test_list_secrets_result_table_display() {
+    let result = ListSecretsResult {
+      entries: vec![
+        Secret {
+          name: Some("secret1".to_string()),
+          description: Some("Description 1".to_string()),
+          uri: Some("arn:aws:secretsmanager:us-east-1:123456789012:secret:secret1".to_string()),
+        },
+        Secret {
+          name: Some("very-long-secret-name-that-exceeds-twenty-chars".to_string()),
+          description: Some(
+            "Very long description that also exceeds twenty characters".to_string(),
+          ),
+          uri: Some("arn:aws:secretsmanager:us-east-1:123456789012:secret:long".to_string()),
+        },
+      ],
+    };
+
+    let table = result.table_display();
+    assert!(table.contains("Name"));
+    assert!(table.contains("Description"));
+    assert!(table.contains("URI"));
+    assert!(table.contains("secret1"));
+    assert!(table.contains("Description 1"));
+    assert!(table.contains("very-long-secret-nam"));
+    assert!(table.contains("Very long descriptio"));
+  }
+
+  #[test]
+  fn test_list_secrets_result_iter() {
+    let result = ListSecretsResult {
+      entries: vec![
+        Secret {
+          name: Some("secret1".to_string()),
+          description: None,
+          uri: None,
+        },
+        Secret {
+          name: Some("secret2".to_string()),
+          description: None,
+          uri: None,
+        },
+      ],
+    };
+
+    let names: Vec<String> = result.iter().filter_map(|s| s.name.clone()).collect();
+
+    assert_eq!(names.len(), 2);
+    assert!(names.contains(&"secret1".to_string()));
+    assert!(names.contains(&"secret2".to_string()));
+  }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,24 +22,36 @@ pub enum NysmError {
   IO(#[from] std::io::Error),
 
   /// Error occurs when retrieving a list of secrets from a provider fails.
-  #[error("Unable to retrieve list of secrets from aws response")]
-  AwsListSecretsNoList,
+  #[error("Failed to list secrets: {0}")]
+  ListSecretsFailed(String),
 
-  /// Error occurs when a specific secret has no string value.
-  #[error("Unable to retrieve string value from aws response")]
-  AwsSecretValueNoValueString,
+  /// Error occurs when a specific secret value cannot be retrieved.
+  #[error("Failed to retrieve secret value: {0}")]
+  GetSecretValueFailed(String),
 
-  /// Error occurs when updating a secret's string value fails
-  #[error("Unable to update secret value")]
-  AwsSecretValueUpdate,
+  /// Error occurs when the secret does not support read operations.
+  #[error("Secret does not support read operations")]
+  SecretNotReadable,
 
-  /// Error occurs when creating a secret fails
-  #[error("Unable to create secret")]
-  AwsSecretValueCreate,
+  /// Error occurs when updating a secret's value fails.
+  #[error("Failed to update secret: {0}")]
+  UpdateSecretFailed(String),
 
-  /// Error occurs when deleting a secret fails
-  #[error("Unable to delete secret")]
-  AwsSecretValueDelete,
+  /// Error occurs when creating a secret fails.
+  #[error("Failed to create secret: {0}")]
+  CreateSecretFailed(String),
+
+  /// Error occurs when deleting a secret fails.
+  #[error("Failed to delete secret: {0}")]
+  DeleteSecretFailed(String),
+
+  /// Error occurs when authentication with a provider fails.
+  #[error("Authentication failed: {0}")]
+  AuthenticationFailed(String),
+
+  /// Error occurs when provider configuration is invalid.
+  #[error("Invalid configuration: {0}")]
+  InvalidConfiguration(String),
 }
 
 impl PartialEq for NysmError {
@@ -85,39 +97,66 @@ mod tests {
   }
 
   #[test]
-  fn test_aws_list_secrets_no_list_error() {
-    let error = NysmError::AwsListSecretsNoList;
+  fn test_list_secrets_failed_error() {
+    let error = NysmError::ListSecretsFailed("connection timeout".to_string());
     assert_eq!(
       error.to_string(),
-      "Unable to retrieve list of secrets from aws response"
+      "Failed to list secrets: connection timeout"
     );
   }
 
   #[test]
-  fn test_aws_secret_value_no_value_string_error() {
-    let error = NysmError::AwsSecretValueNoValueString;
+  fn test_get_secret_value_failed_error() {
+    let error = NysmError::GetSecretValueFailed("secret not found".to_string());
     assert_eq!(
       error.to_string(),
-      "Unable to retrieve string value from aws response"
+      "Failed to retrieve secret value: secret not found"
     );
   }
 
   #[test]
-  fn test_aws_secret_value_update_error() {
-    let error = NysmError::AwsSecretValueUpdate;
-    assert_eq!(error.to_string(), "Unable to update secret value");
+  fn test_secret_not_readable_error() {
+    let error = NysmError::SecretNotReadable;
+    assert_eq!(error.to_string(), "Secret does not support read operations");
   }
 
   #[test]
-  fn test_aws_secret_value_create_error() {
-    let error = NysmError::AwsSecretValueCreate;
-    assert_eq!(error.to_string(), "Unable to create secret");
+  fn test_update_secret_failed_error() {
+    let error = NysmError::UpdateSecretFailed("permission denied".to_string());
+    assert_eq!(
+      error.to_string(),
+      "Failed to update secret: permission denied"
+    );
   }
 
   #[test]
-  fn test_aws_secret_value_delete_error() {
-    let error = NysmError::AwsSecretValueDelete;
-    assert_eq!(error.to_string(), "Unable to delete secret");
+  fn test_create_secret_failed_error() {
+    let error = NysmError::CreateSecretFailed("secret already exists".to_string());
+    assert_eq!(
+      error.to_string(),
+      "Failed to create secret: secret already exists"
+    );
+  }
+
+  #[test]
+  fn test_delete_secret_failed_error() {
+    let error = NysmError::DeleteSecretFailed("secret in use".to_string());
+    assert_eq!(error.to_string(), "Failed to delete secret: secret in use");
+  }
+
+  #[test]
+  fn test_authentication_failed_error() {
+    let error = NysmError::AuthenticationFailed("invalid token".to_string());
+    assert_eq!(error.to_string(), "Authentication failed: invalid token");
+  }
+
+  #[test]
+  fn test_invalid_configuration_error() {
+    let error = NysmError::InvalidConfiguration("missing repository name".to_string());
+    assert_eq!(
+      error.to_string(),
+      "Invalid configuration: missing repository name"
+    );
   }
 
   #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,29 @@
 #![cfg(not(tarpaulin_include))]
 use clap::Parser;
-use nysm::{cli::ArgumentParser, provider::aws::AwsClient};
+use nysm::{
+  cli::{ArgumentParser, Provider},
+  client::QuerySecrets,
+  provider::{aws::AwsClient, github::GitHubClient},
+};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+  rustls::crypto::ring::default_provider()
+    .install_default()
+    .expect("Failed to install rustls crypto provider");
+
   let cli = ArgumentParser::parse();
-  let client = AwsClient::new(cli.region.clone()).await;
+
+  let client: Box<dyn QuerySecrets> = match cli.provider {
+    Provider::Aws => Box::new(AwsClient::new(cli.region.clone()).await),
+    Provider::Github => {
+      let token = cli.github_token.clone().unwrap();
+      let owner = cli.github_owner.clone().unwrap();
+      let repo = cli.github_repo.clone().unwrap();
+
+      Box::new(GitHubClient::new(token, owner, repo)?)
+    }
+  };
 
   cli.run_subcommand(client).await;
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,2 +1,4 @@
 /// Defines an AWS provider implementation
 pub mod aws;
+/// Defines a GitHub provider implementation
+pub mod github;

--- a/src/provider/aws.rs
+++ b/src/provider/aws.rs
@@ -133,7 +133,10 @@ impl QuerySecrets for AwsClient {
 
         Ok(ListSecretsResult { entries })
       }
-      Err(_) => Err(NysmError::AwsListSecretsNoList),
+      Err(e) => Err(NysmError::ListSecretsFailed(format!(
+        "AWS Secrets Manager: {}",
+        e
+      ))),
     }
   }
 
@@ -149,7 +152,10 @@ impl QuerySecrets for AwsClient {
       .await
     {
       Ok(secret) => Ok(secret.into()),
-      Err(_) => Err(NysmError::AwsSecretValueNoValueString),
+      Err(e) => Err(NysmError::GetSecretValueFailed(format!(
+        "AWS Secrets Manager: {}",
+        e
+      ))),
     }
   }
 
@@ -167,7 +173,10 @@ impl QuerySecrets for AwsClient {
       .await
     {
       Ok(secret) => Ok(secret.into()),
-      Err(_) => Err(NysmError::AwsSecretValueUpdate),
+      Err(e) => Err(NysmError::UpdateSecretFailed(format!(
+        "AWS Secrets Manager: {}",
+        e
+      ))),
     }
   }
 
@@ -189,7 +198,10 @@ impl QuerySecrets for AwsClient {
 
     match request.send().await {
       Ok(secret) => Ok(secret.into()),
-      Err(_) => Err(NysmError::AwsSecretValueCreate),
+      Err(e) => Err(NysmError::CreateSecretFailed(format!(
+        "AWS Secrets Manager: {}",
+        e
+      ))),
     }
   }
 
@@ -202,7 +214,10 @@ impl QuerySecrets for AwsClient {
       .await
     {
       Ok(secret) => Ok(secret.into()),
-      Err(_) => Err(NysmError::AwsSecretValueDelete),
+      Err(e) => Err(NysmError::DeleteSecretFailed(format!(
+        "AWS Secrets Manager: {}",
+        e
+      ))),
     }
   }
 }

--- a/src/provider/github.rs
+++ b/src/provider/github.rs
@@ -1,0 +1,240 @@
+#![deny(missing_docs)]
+#![cfg(not(tarpaulin_include))]
+use crate::client::{
+  CreateSecretResult, DeleteSecretResult, GetSecretValueResult, ListSecretsResult, QuerySecrets,
+  UpdateSecretValueResult,
+};
+use crate::error::NysmError;
+
+use async_trait::async_trait;
+use base64::{Engine, engine::general_purpose::STANDARD};
+use octocrab::Octocrab;
+use octocrab::models::PublicKey;
+use octocrab::models::repos::secrets::{CreateRepositorySecret, RepositorySecret};
+
+/// Wrapper struct to hold a GitHub API client that implements
+/// the [QuerySecrets] trait for GitHub Actions secrets.
+///
+/// GitHub Actions secrets are write-only - you cannot retrieve
+/// their values through the API. This provider supports listing,
+/// creating, updating, and deleting secrets, but not reading values.
+///
+/// # Example
+/// ```rust,no_run
+/// use nysm::provider::github::GitHubClient;
+///
+/// # let rt = tokio::runtime::Runtime::new().unwrap();
+/// # rt.block_on(async {
+/// let client = GitHubClient::new(
+///     "ghp_xxxxxxxxxxxx".to_string(),
+///     "owner".to_string(),
+///     "repo".to_string()
+/// ).unwrap();
+/// # })
+/// ```
+pub struct GitHubClient {
+  client: Octocrab,
+  owner: String,
+  repo: String,
+}
+
+impl GitHubClient {
+  /// Create a new GitHub client with authentication token and repository information.
+  ///
+  /// # Arguments
+  /// * `token` - GitHub personal access token or GITHUB_TOKEN
+  /// * `owner` - Repository owner (user or organization)
+  /// * `repo` - Repository name
+  ///
+  /// # Returns
+  /// Returns a Result containing the GitHubClient or an error if configuration is invalid.
+  pub fn new(token: String, owner: String, repo: String) -> Result<Self, NysmError> {
+    if token.is_empty() {
+      return Err(NysmError::InvalidConfiguration(
+        "GitHub token cannot be empty".to_string(),
+      ));
+    }
+
+    if owner.is_empty() {
+      return Err(NysmError::InvalidConfiguration(
+        "GitHub owner cannot be empty".to_string(),
+      ));
+    }
+
+    if repo.is_empty() {
+      return Err(NysmError::InvalidConfiguration(
+        "GitHub repository name cannot be empty".to_string(),
+      ));
+    }
+
+    let client = Octocrab::builder()
+      .personal_token(token)
+      .build()
+      .map_err(|e| {
+        NysmError::InvalidConfiguration(format!("Failed to create GitHub client: {}", e))
+      })?;
+
+    Ok(Self {
+      client,
+      owner,
+      repo,
+    })
+  }
+
+  /// Get the repository's public key for encrypting secrets.
+  async fn get_repo_public_key(&self) -> Result<PublicKey, NysmError> {
+    self
+      .client
+      .repos(&self.owner, &self.repo)
+      .secrets()
+      .get_public_key()
+      .await
+      .map_err(|e| {
+        NysmError::AuthenticationFailed(format!("Failed to get repository public key: {}", e))
+      })
+  }
+
+  /// Encrypt a secret value using the repository's public key.
+  fn encrypt_secret(
+    &self,
+    public_key: &PublicKey,
+    secret_value: &str,
+  ) -> Result<String, NysmError> {
+    sodiumoxide::init().map_err(|_| {
+      NysmError::InvalidConfiguration("Failed to initialize sodium crypto library".to_string())
+    })?;
+
+    let key_bytes = STANDARD
+      .decode(&public_key.key)
+      .map_err(|e| NysmError::InvalidConfiguration(format!("Invalid public key format: {}", e)))?;
+
+    let public_key = sodiumoxide::crypto::box_::PublicKey::from_slice(&key_bytes)
+      .ok_or_else(|| NysmError::InvalidConfiguration("Invalid public key".to_string()))?;
+
+    let encrypted = sodiumoxide::crypto::sealedbox::seal(secret_value.as_bytes(), &public_key);
+
+    Ok(STANDARD.encode(encrypted))
+  }
+}
+
+#[async_trait]
+impl QuerySecrets for GitHubClient {
+  fn supports_read(&self) -> bool {
+    false
+  }
+
+  async fn secrets_list(&self) -> Result<ListSecretsResult, NysmError> {
+    let secrets = self
+      .client
+      .repos(&self.owner, &self.repo)
+      .secrets()
+      .get_secrets()
+      .await
+      .map_err(|e| match e {
+        octocrab::Error::GitHub { source, .. } => {
+          NysmError::ListSecretsFailed(format!("GitHub API error: {}", source.message))
+        }
+        _ => NysmError::ListSecretsFailed(format!("GitHub API error: {}", e)),
+      })?;
+
+    let entries = secrets
+      .secrets
+      .into_iter()
+      .map(|secret: RepositorySecret| crate::client::Secret {
+        name: Some(secret.name.clone()),
+        uri: Some(format!(
+          "/repos/{}/{}/actions/secrets/{}",
+          self.owner, self.repo, secret.name
+        )),
+        description: None,
+      })
+      .collect();
+
+    Ok(ListSecretsResult { entries })
+  }
+
+  async fn secret_value(&self, _secret_id: String) -> Result<GetSecretValueResult, NysmError> {
+    Err(NysmError::SecretNotReadable)
+  }
+
+  async fn update_secret_value(
+    &self,
+    secret_id: String,
+    secret_value: String,
+  ) -> Result<UpdateSecretValueResult, NysmError> {
+    let public_key = self.get_repo_public_key().await?;
+    let encrypted_value = self.encrypt_secret(&public_key, &secret_value)?;
+
+    self
+      .client
+      .repos(&self.owner, &self.repo)
+      .secrets()
+      .create_or_update_secret(
+        &secret_id,
+        &CreateRepositorySecret {
+          encrypted_value: &encrypted_value,
+          key_id: &public_key.key_id,
+        },
+      )
+      .await
+      .map_err(|e| NysmError::UpdateSecretFailed(format!("GitHub API error: {}", e)))?;
+
+    Ok(UpdateSecretValueResult {
+      name: Some(secret_id.clone()),
+      uri: Some(format!(
+        "/repos/{}/{}/actions/secrets/{}",
+        self.owner, self.repo, secret_id
+      )),
+      version_id: None,
+    })
+  }
+
+  async fn create_secret(
+    &self,
+    secret_id: String,
+    secret_value: String,
+    _description: Option<String>,
+  ) -> Result<CreateSecretResult, NysmError> {
+    let public_key = self.get_repo_public_key().await?;
+    let encrypted_value = self.encrypt_secret(&public_key, &secret_value)?;
+
+    self
+      .client
+      .repos(&self.owner, &self.repo)
+      .secrets()
+      .create_or_update_secret(
+        &secret_id,
+        &CreateRepositorySecret {
+          encrypted_value: &encrypted_value,
+          key_id: &public_key.key_id,
+        },
+      )
+      .await
+      .map_err(|e| NysmError::CreateSecretFailed(format!("GitHub API error: {}", e)))?;
+
+    Ok(CreateSecretResult {
+      name: Some(secret_id.clone()),
+      uri: Some(format!(
+        "/repos/{}/{}/actions/secrets/{}",
+        self.owner, self.repo, secret_id
+      )),
+      version_id: None,
+    })
+  }
+
+  async fn delete_secret(&self, secret_id: String) -> Result<DeleteSecretResult, NysmError> {
+    self
+      .client
+      .repos(&self.owner, &self.repo)
+      .secrets()
+      .delete_secret(&secret_id)
+      .await
+      .map_err(|e| NysmError::DeleteSecretFailed(format!("GitHub API error: {}", e)))?;
+
+    Ok(DeleteSecretResult {
+      name: Some(secret_id),
+      uri: None,
+      deletion_date: None,
+    })
+  }
+}


### PR DESCRIPTION
In order to enable github actions secrets as a secrets provider, this
commit adds the necessary logic to handle github. It also adds
'capabilities' to providers which lets us treat certain providers
different (e.g. github is write only for secrets whereas aws is
read/write).
