### PR TITLE
Add doppler support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn",
  "which",
@@ -747,6 +747,12 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1226,9 +1232,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1521,6 +1529,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1542,6 +1551,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1549,7 +1559,9 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1704,6 +1716,12 @@ dependencies = [
  "hashbrown",
  "serde",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
@@ -1895,6 +1913,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,6 +2027,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "octocrab",
+ "reqwest",
  "rustls 0.23.27",
  "serde",
  "serde_json",
@@ -2235,6 +2260,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,6 +2319,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.27",
+ "socket2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.27",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2387,35 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
 
 [[package]]
 name = "rayon"
@@ -2364,6 +2482,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.27",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2397,6 +2553,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -2500,6 +2662,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2890,6 +3053,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3109,6 +3275,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3455,6 +3636,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3487,6 +3681,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,6 +3699,15 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ base64 = "0.22"
 bat = "0.25"
 clap = { version = "4.4", features = ["derive", "env"]}
 octocrab = "0.44"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 rustls = { version = "0.23", features = ["ring"] }
 serde = { version = "1", features = ["derive"] }
 sodiumoxide = "0.2"

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -2,3 +2,5 @@
 pub mod aws;
 /// Defines a GitHub provider implementation
 pub mod github;
+/// Defines a Doppler provider implementation
+pub mod doppler;

--- a/src/provider/doppler.rs
+++ b/src/provider/doppler.rs
@@ -1,0 +1,316 @@
+#![deny(missing_docs)]
+#![cfg(not(tarpaulin_include))]
+use crate::client::{
+  CreateSecretResult, DeleteSecretResult, GetSecretValueResult, ListSecretsResult, QuerySecrets,
+  Secret, UpdateSecretValueResult,
+};
+use crate::error::NysmError;
+
+use async_trait::async_trait;
+use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Debug, Deserialize)]
+struct DopplerListSecretsResponse {
+  secrets: std::collections::HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DopplerSecretResponse {
+  value: DopplerSecretValue,
+}
+
+#[derive(Debug, Deserialize)]
+struct DopplerSecretValue {
+  raw: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DopplerUpdateSecretRequest {
+  secrets: std::collections::HashMap<String, String>,
+}
+
+/// Wrapper struct to hold a Doppler API client that implements
+/// the [QuerySecrets] trait for Doppler secrets management.
+///
+/// Doppler is a centralized secrets management platform that provides
+/// secure storage and retrieval of secrets across environments.
+///
+/// # Example
+/// ```rust,no_run
+/// use nysm::provider::doppler::DopplerClient;
+///
+/// # let rt = tokio::runtime::Runtime::new().unwrap();
+/// # rt.block_on(async {
+/// let client = DopplerClient::new(
+///     "dp.st.xxxxxxxxxxxx".to_string(),
+///     "dev".to_string(),
+///     "backend".to_string()
+/// ).unwrap();
+/// # })
+/// ```
+pub struct DopplerClient {
+  client: Client,
+  token: String,
+  project: String,
+  config: String,
+}
+
+impl DopplerClient {
+  /// Create a new Doppler client with authentication token and project information.
+  ///
+  /// # Arguments
+  /// * `token` - Doppler service token (format: dp.st.xxxx)
+  /// * `project` - Doppler project name
+  /// * `config` - Doppler config/environment name (e.g., "dev", "staging", "prod")
+  ///
+  /// # Returns
+  /// Returns a Result containing the DopplerClient or an error if configuration is invalid.
+  pub fn new(token: String, project: String, config: String) -> Result<Self, NysmError> {
+    if token.is_empty() {
+      return Err(NysmError::InvalidConfiguration(
+        "Doppler token cannot be empty".to_string(),
+      ));
+    }
+
+    if !token.starts_with("dp.") {
+      return Err(NysmError::InvalidConfiguration(
+        "Invalid Doppler token format. Expected format: dp.xx.xxxx".to_string(),
+      ));
+    }
+
+    if project.is_empty() {
+      return Err(NysmError::InvalidConfiguration(
+        "Doppler project cannot be empty".to_string(),
+      ));
+    }
+
+    if config.is_empty() {
+      return Err(NysmError::InvalidConfiguration(
+        "Doppler config cannot be empty".to_string(),
+      ));
+    }
+
+    let client = Client::builder()
+      .use_rustls_tls()
+      .build()
+      .map_err(|e| NysmError::InvalidConfiguration(format!("Failed to create HTTP client: {}", e)))?;
+
+    Ok(Self {
+      client,
+      token,
+      project,
+      config,
+    })
+  }
+
+  fn get_base_url(&self) -> String {
+    format!("https://api.doppler.com/v3/configs/config")
+  }
+
+  fn get_auth_header(&self) -> (&str, String) {
+    ("Authorization", format!("Bearer {}", self.token))
+  }
+
+  fn get_project_params(&self) -> Vec<(&str, &str)> {
+    vec![("project", &self.project), ("config", &self.config)]
+  }
+}
+
+#[async_trait]
+impl QuerySecrets for DopplerClient {
+  async fn secrets_list(&self) -> Result<ListSecretsResult, NysmError> {
+    let url = format!("{}/secrets", self.get_base_url());
+    
+    let response = self
+      .client
+      .get(&url)
+      .header(self.get_auth_header().0, self.get_auth_header().1)
+      .query(&self.get_project_params())
+      .send()
+      .await
+      .map_err(|e| NysmError::ListSecretsFailed(format!("Doppler API request failed: {}", e)))?;
+
+    match response.status() {
+      StatusCode::OK => {
+        let data: DopplerListSecretsResponse = response
+          .json()
+          .await
+          .map_err(|e| NysmError::ListSecretsFailed(format!("Failed to parse response: {}", e)))?;
+
+        let entries = data
+          .secrets
+          .into_iter()
+          .map(|(name, _)| Secret {
+            name: Some(name.clone()),
+            uri: Some(format!("{}/{}?project={}&config={}", 
+              self.get_base_url(), 
+              name,
+              self.project,
+              self.config
+            )),
+            description: None,
+          })
+          .collect();
+
+        Ok(ListSecretsResult { entries })
+      }
+      StatusCode::UNAUTHORIZED => Err(NysmError::AuthenticationFailed(
+        "Invalid Doppler token".to_string(),
+      )),
+      status => {
+        let error_text = response.text().await.unwrap_or_default();
+        Err(NysmError::ListSecretsFailed(format!(
+          "Doppler API error ({}): {}",
+          status, error_text
+        )))
+      }
+    }
+  }
+
+  async fn secret_value(&self, secret_id: String) -> Result<GetSecretValueResult, NysmError> {
+    let url = format!("{}/secret", self.get_base_url());
+    
+    let mut params = self.get_project_params();
+    params.push(("name", &secret_id));
+
+    let response = self
+      .client
+      .get(&url)
+      .header(self.get_auth_header().0, self.get_auth_header().1)
+      .query(&params)
+      .send()
+      .await
+      .map_err(|e| NysmError::GetSecretValueFailed(format!("Doppler API request failed: {}", e)))?;
+
+    match response.status() {
+      StatusCode::OK => {
+        let data: DopplerSecretResponse = response
+          .json()
+          .await
+          .map_err(|e| NysmError::GetSecretValueFailed(format!("Failed to parse response: {}", e)))?;
+
+        Ok(GetSecretValueResult {
+          secret: data.value.raw,
+        })
+      }
+      StatusCode::UNAUTHORIZED => Err(NysmError::AuthenticationFailed(
+        "Invalid Doppler token".to_string(),
+      )),
+      StatusCode::NOT_FOUND => Err(NysmError::GetSecretValueFailed(format!(
+        "Secret '{}' not found in project '{}' config '{}'",
+        secret_id, self.project, self.config
+      ))),
+      status => {
+        let error_text = response.text().await.unwrap_or_default();
+        Err(NysmError::GetSecretValueFailed(format!(
+          "Doppler API error ({}): {}",
+          status, error_text
+        )))
+      }
+    }
+  }
+
+  async fn update_secret_value(
+    &self,
+    secret_id: String,
+    secret_value: String,
+  ) -> Result<UpdateSecretValueResult, NysmError> {
+    let url = format!("{}/secrets", self.get_base_url());
+    
+    let mut secrets = std::collections::HashMap::new();
+    secrets.insert(secret_id.clone(), secret_value);
+
+    let request_body = DopplerUpdateSecretRequest { secrets };
+
+    let response = self
+      .client
+      .post(&url)
+      .header(self.get_auth_header().0, self.get_auth_header().1)
+      .header("Content-Type", "application/json")
+      .query(&self.get_project_params())
+      .json(&request_body)
+      .send()
+      .await
+      .map_err(|e| NysmError::UpdateSecretFailed(format!("Doppler API request failed: {}", e)))?;
+
+    match response.status() {
+      StatusCode::OK => {
+        Ok(UpdateSecretValueResult {
+          name: Some(secret_id.clone()),
+          uri: Some(format!("{}/{}?project={}&config={}", 
+            self.get_base_url(), 
+            secret_id,
+            self.project,
+            self.config
+          )),
+          version_id: None,
+        })
+      }
+      StatusCode::UNAUTHORIZED => Err(NysmError::AuthenticationFailed(
+        "Invalid Doppler token".to_string(),
+      )),
+      status => {
+        let error_text = response.text().await.unwrap_or_default();
+        Err(NysmError::UpdateSecretFailed(format!(
+          "Doppler API error ({}): {}",
+          status, error_text
+        )))
+      }
+    }
+  }
+
+  async fn create_secret(
+    &self,
+    secret_id: String,
+    secret_value: String,
+    _description: Option<String>,
+  ) -> Result<CreateSecretResult, NysmError> {
+    let result = self.update_secret_value(secret_id.clone(), secret_value).await?;
+
+    Ok(CreateSecretResult {
+      name: result.name,
+      uri: result.uri,
+      version_id: result.version_id,
+    })
+  }
+
+  async fn delete_secret(&self, secret_id: String) -> Result<DeleteSecretResult, NysmError> {
+    let url = format!("{}/secret", self.get_base_url());
+    
+    let response = self
+      .client
+      .delete(&url)
+      .header(self.get_auth_header().0, self.get_auth_header().1)
+      .query(&self.get_project_params())
+      .json(&json!({ "name": secret_id }))
+      .send()
+      .await
+      .map_err(|e| NysmError::DeleteSecretFailed(format!("Doppler API request failed: {}", e)))?;
+
+    match response.status() {
+      StatusCode::OK | StatusCode::NO_CONTENT => {
+        Ok(DeleteSecretResult {
+          name: Some(secret_id),
+          uri: None,
+          deletion_date: None,
+        })
+      }
+      StatusCode::UNAUTHORIZED => Err(NysmError::AuthenticationFailed(
+        "Invalid Doppler token".to_string(),
+      )),
+      StatusCode::NOT_FOUND => Err(NysmError::DeleteSecretFailed(format!(
+        "Secret '{}' not found in project '{}' config '{}'",
+        secret_id, self.project, self.config
+      ))),
+      status => {
+        let error_text = response.text().await.unwrap_or_default();
+        Err(NysmError::DeleteSecretFailed(format!(
+          "Doppler API error ({}): {}",
+          status, error_text
+        )))
+      }
+    }
+  }
+}


### PR DESCRIPTION
In order to enable using nysm with doppler for secrets management, this
commit adds the doppler provider. Additionally, it makes each provider
supported a subcommand from the top level command. This allows each
provider to have their own set of flags. This is necessary as each
provider needs support for differing arguments and values.
