### PR TITLE
Update windows artifact build image

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -23,3 +23,4 @@ allow-dirty = ["ci", "msi"]
 aarch64-unknown-linux-gnu = "ubuntu-22.04"
 x86_64-unknown-linux-gnu = "ubuntu-22.04"
 x86_64-unknown-linux-musl = "ubuntu-22.04"
+x86_64-pc-windows-msvc = "windows-2022"


### PR DESCRIPTION
This commit updates the artifact builder for windows builds to use
windows-2022 as windows-2019 has been deprecated on github.
